### PR TITLE
Update to fix table mismatch error

### DIFF
--- a/ED-IBE/MainTabs/tabPriceAnalysis.cs
+++ b/ED-IBE/MainTabs/tabPriceAnalysis.cs
@@ -691,7 +691,7 @@ namespace IBE.MTPriceAnalysis
                         DataTable tmpTable = new DataTable();
                         Program.DBCon.Execute(sqlString, tmpTable);
 
-                        m_DGVTables[cmbByStation.Name].Merge(tmpTable);
+                        m_DGVTables[cmbByStation.Name].Merge(tmpTable, true, MissingSchemaAction.Ignore);
 
                         DataRow separatorRow = m_DGVTables[cmbByStation.Name].NewRow();
                         separatorRow["SystemID"]        = "0";


### PR DESCRIPTION
In reference to exception.

23.01.2017 06:30:48 : .time and .time have conflicting properties: DataType property mismatch.
23.01.2017 06:30:48 : at System.Data.Merger.MergeSchema(DataTable table)
at System.Data.Merger.MergeTableData(DataTable src)
at System.Data.Merger.MergeTable(DataTable src)
at System.Data.DataTable.Merge(DataTable table, Boolean preserveChanges, MissingSchemaAction missingSchemaAction)
at IBE.MTPriceAnalysis.tabPriceAnalysis.createNewBaseView() in E:\dev\RN\ED-IBE\ED-IBE\MainTabs\tabPriceAnalysis.cs:line 696